### PR TITLE
Fix minor issues

### DIFF
--- a/gitlab-ci-runner/Program.cs
+++ b/gitlab-ci-runner/Program.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.IO;
+using System.Reflection;
 using gitlab_ci_runner.conf;
 using gitlab_ci_runner.runner;
 using gitlab_ci_runner.setup;
@@ -13,22 +15,25 @@ namespace gitlab_ci_runner
     {
         static void Main(string[] args)
         {
+            Console.InputEncoding = Encoding.Default;
+            Console.OutputEncoding = Encoding.Default;
             ServicePointManager.DefaultConnectionLimit = 999;
-            Console.WriteLine("Starting Gitlab CI Runner for Windows");
-            Config.loadConfig();
-            if (Config.isConfigured())
-            {
-                // Load the runner
-                Runner.run();
-            }
-            else
-            {
-                // Load the setup
-                Setup.run();
+            if (Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location).Substring(0, 1) == @"\") {
+                Console.WriteLine("Can't run on UNC Path");
+            } else {
+                Console.WriteLine("Starting Gitlab CI Runner for Windows");
+                Config.loadConfig();
+                if (Config.isConfigured()) {
+                    // Load the runner
+                    Runner.run();
+                } else {
+                    // Load the setup
+                    Setup.run();
+                }
             }
             Console.WriteLine();
             Console.WriteLine("Runner quit. Press any key to exit!");
-            Console.ReadLine();
+            Console.ReadKey();
         }
     }
 }

--- a/gitlab-ci-runner/helper/Network.cs
+++ b/gitlab-ci-runner/helper/Network.cs
@@ -15,6 +15,19 @@ namespace gitlab_ci_runner.helper
 {
     class Network
     {
+		private static string webRequest(string sUrl, string sMethod, string sContent) {
+			WebRequest wr = HttpWebRequest.Create(sUrl);
+			wr.ContentType = "application/x-www-form-urlencoded;charset=utf-8";
+			wr.ContentLength = sContent.Length;
+			wr.Timeout = 2500;
+			wr.Method = sMethod;
+			StreamWriter requestStream = new StreamWriter(wr.GetRequestStream(), Encoding.ASCII);
+			requestStream.Write(sContent);
+			requestStream.Close();
+			StreamReader responseRequest = new StreamReader(wr.GetResponse().GetResponseStream(), Encoding.UTF8);
+			return responseRequest.ReadToEnd();
+		}
+		
         /// <summary>
         /// PUT a String to an URL
         /// </summary>
@@ -25,10 +38,7 @@ namespace gitlab_ci_runner.helper
         {
             try
             {
-                WebClient wc = new WebClient();
-                wc.Headers["Content-Type"] = "application/x-www-form-urlencoded";
-                wc.Headers["Accept"] = "*/*";
-                return wc.UploadString(sUrl, "PUT", sContent);
+                return webRequest(sUrl, "PUT",sContent);
             }
             catch (Exception)
             {
@@ -49,10 +59,7 @@ namespace gitlab_ci_runner.helper
             {
                 try
                 {
-                    WebClient wc = new WebClient();
-                    wc.Headers["Content-Type"] = "application/x-www-form-urlencoded";
-                    wc.Headers["Accept"] = "*/*";
-                    return wc.UploadString(sUrl, "POST", sContent);
+                    return webRequest(sUrl, "POST", sContent);
                 }
                 catch (Exception)
                 {
@@ -121,7 +128,7 @@ namespace gitlab_ci_runner.helper
                         BuildInfo info = new BuildInfo();
                         info.id = obj.Get<int>("id");
                         info.project_id = obj.Get<int>("project_id");
-                        info.commands = obj.Get<string[]>("commands");
+						info.commands = System.Text.RegularExpressions.Regex.Replace(obj.Get<string>("commands"), "[\r|\n]+$", "\n").Split('\n');
                         info.repo_url = obj.Get("repo_url");
                         info.reference = obj.Get("sha");
                         info.ref_name = obj.Get("ref");

--- a/gitlab-ci-runner/runner/Build.cs
+++ b/gitlab-ci-runner/runner/Build.cs
@@ -46,8 +46,7 @@ namespace gitlab_ci_runner.runner
                 {
                     sOut += line + "\n";
                 }
-                byte[] bytes = Encoding.Default.GetBytes(sOut);
-                return Encoding.UTF8.GetString(bytes);
+				return sOut;
             }
         }
 


### PR DESCRIPTION
- Force output by Default Encoding
- Reject Executing path is begin with UNC path
- There is no need to convert to UTF8 after Uri.EscapeDataString
- Fix commands 'ls -la' will execute 'ls' and 'la' issue, and now, it will split by '\n'

TODO: if commands contains '\\\n' it may occur an error, so it need to replace by ' ', and needs to confirm
