### PR TITLE
fix compatibility with old version of GitLab CI which doesn't support timeout parameter and trim commands' CR and LF characters

### DIFF
--- a/gitlab-ci-runner/helper/Network.cs
+++ b/gitlab-ci-runner/helper/Network.cs
@@ -129,12 +129,12 @@ namespace gitlab_ci_runner.helper
                         info.id = obj.Get<int>("id");
                         info.project_id = obj.Get<int>("project_id");
                         info.project_name = obj.Get("project_name");
-                        info.commands = System.Text.RegularExpressions.Regex.Replace(obj.Get<string>("commands"), "[\r|\n]+$", "\n").Split('\n');
+                        info.commands = System.Text.RegularExpressions.Regex.Replace(obj.Get<string>("commands"), "[\r|\n]+", "\n").Split('\n');
                         info.repo_url = obj.Get("repo_url");
                         info.sha = obj.Get("sha");
                         info.before_sha = obj.Get("before_sha");
                         info.ref_name = obj.Get("ref");
-                        info.timeout = obj.Get<int>("timeout");
+						info.timeout = int.Parse(obj.Get("timeout") ?? "1800");
                         info.allow_git_fetch = obj.Get<bool>("allow_git_fetch");
                         return info;
                     }


### PR DESCRIPTION
fix compatibility with old version of GitLab CI which doesn't support timeout parameter and trim commands' CR and LF characters
- set timeout=1800(GitLab CI default value) when JSON doesn't have timeout parameter, because old version of GitLab CI doesn't have timeout parameter in JSON response, so it will return null to info.timeout by fill 0, that occurred any command terminate immediately.
