### PR TITLE
Fixed commands parsing - don't treat pipe (|) character as a new line separator

### DIFF
--- a/gitlab-ci-runner/helper/Network.cs
+++ b/gitlab-ci-runner/helper/Network.cs
@@ -129,7 +129,7 @@ namespace gitlab_ci_runner.helper
                         info.id = obj.Get<int>("id");
                         info.project_id = obj.Get<int>("project_id");
                         info.project_name = obj.Get("project_name");
-                        info.commands = System.Text.RegularExpressions.Regex.Replace(obj.Get<string>("commands"), "[\r|\n]+", "\n").Split('\n');
+                        info.commands = System.Text.RegularExpressions.Regex.Replace(obj.Get<string>("commands"), "(\r|\n)+", "\n").Split('\n');
                         info.repo_url = obj.Get("repo_url");
                         info.sha = obj.Get("sha");
                         info.before_sha = obj.Get("before_sha");


### PR DESCRIPTION
This is to keep pipe characters in the commands. Otherwise they are getting replaced with \n due to invalid regex pattern: [\r|\n], which I guess supposed to be (\r|\n)
