### PR TITLE
Removed string escape of trace to make the output at GitLab CI more presentable

### DIFF
--- a/gitlab-ci-runner/helper/Network.cs
+++ b/gitlab-ci-runner/helper/Network.cs
@@ -127,7 +127,7 @@ namespace gitlab_ci_runner.helper
             
             var trace = new StringBuilder();
             foreach (string t in sTrace.Split('\n'))
-                trace.Append(Uri.EscapeDataString(t)).Append("\n");
+                trace.Append(t).Append("\n");
 
             int iTry = 0;
             while (iTry <= 5)


### PR DESCRIPTION
Linked to issue #27
