### PR TITLE
Added configuration of pre-build steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,104 @@ To register the runner as service try the [NSSM](http://nssm.cc/). But remember 
 Options
 -------
 
-If your CI server is using a self-signed certificate you can add -sslbypass option in argument 
+If your CI server is using a self-signed certificate you can add -sslbypass option in argument
+
+How it works
+------------
+
+The whole thing works in the following way:
+
+  1. The runner should be endlessly up and listen to the commands from CI (this is why you should use NSSM or its equivalent).
+  2.  As soon as CI sends a command to the runner it performs the preparation actions (clones or fetches the project from the server to some folder)
+  3. When the project is on the runner's machine, it executes the script you write in the CI control panel.
+
+You may need an additional control how the runner updates the project. For example, you may want to use a particular project folder. Or avoid using `git reset --hard` before each update. Or use `git clone --recursive` instead of simple `git clone`.
+
+To do it, you can additionally configure runner as explained in the next section.
+
+Additional configuration
+------------------------
+
+After the first launch, the runner creates a `runner.cfg` file which holds the URL to the Gitlab CI server and a runner token you should insert when registering the runner there:
+
+```
+[main]
+url=http://ci.gitlab.example.com/
+token=<sometoken>
+```
+
+You may add extra sections (see below how you name them) which may hold the following keys:
+
+- `ProjectDir` - a directory where the project should be created. It may be relative to the runner folder or absolute.
+- `NewRepoInitCommand` - a command which should prepare a new repo
+- `ExistingRepoInitCommand` - a command which should update a repo if it already exists
+- `PostPrepareCommand` - a command which is called after `NewRepoInitCommand` or `ExistingRepoInitCommand` is executed.
+
+### About commands
+
+Commands are executed in the `ProjectDir`, so there is no need to `cd` there.
+
+If you need multiple commands, you can either put concatenate them with `&&` (`git clone {repo_url} && git checkout {commit}`) or put
+them to a `.bat` file.  
+
+If you don't specify commands, by default it will be:
+
+```
+NewRepoInitCommand=git clone {repo_url} {project_dir} && cd {project_dir} && git checkout {commit}
+ExistingRepoInitCommand=git reset --hard && git clean -f && git fetch && git checkout {commit}
+```
+
+### Placeholders
+
+Each of these keys may contain placeholders which will be replaced by a data sent from CI:
+
+  - `{build_id}` - build ID provided by Gitlab CI server
+  - `{project_id}` - project ID provided by Gitlab CI (note, not by Gitlab itself!)
+  - `{project_name}` - a project name including namespace, without whitespaces (e.g. Group1/myproject)
+  - `{project_dir}` - won't be applied for the ProjectDir key.
+  - `{commit}` - uuid which identifies a current commit
+  - `{previous_commit}` - uuid of the previous commit
+  - `{repo_url}` - repo URL
+  - `{ref_name}` - ref name
+
+### Defining different settings for different projects
+
+The same runner may be reused by multiple projects. You may want to have different project with different settings.
+
+To achieve this, you should refer the project in the section name. You can do it either using ID or name:
+
+`[id=123]`
+
+or
+
+`[name=group1/myprojectname]`
+
+You can use the same commands for several projects by separating them with a `|` sign:
+
+`[id=123|id=234|name=group1/someproject]`
+
+At last, you may specify the universal rules using `*` sign:
+
+`[*]`
+
+Note, you should put `[*]` in the end of config, otherwise it will ignore settings for your specific project. You may think about it as `default` in the `switch...case` block.
+
+### Putting things together
+
+It is a time for an example:
+
+``` ini
+[main]
+url=http://ci.gitlab.example.com/
+token=<sometoken>
+[id=123]
+ProjectDir=C:\CI\MyTest
+NewRepoInitCommand=git clone --recursive {repo_url}
+[name=somegroup/someproject|id=124]
+ProjectDir=C:\CI\{project_name}
+NewRepoInitCommand=myclonecommands.bat {project_id} {repo_url}
+ExistingRepoInitCommand=myfetchcommands.bat {project_id} {repo_url}
+[*]
+ProjectDir=C:\defaultprojectdir\project_{project_id}
+PostPrepareDir=echo "ProjDir: {project_dir}, ProjID: {project_id}, ProjName={project_name}, BuildID: {build_id}, RepoUrl: {repo_url}, RefName: {ref_name}, SHA: {sha}, BeforeSHA: {before_sha}"
+```

--- a/gitlab-ci-runner/conf/Config.cs
+++ b/gitlab-ci-runner/conf/Config.cs
@@ -5,12 +5,71 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
+using System.Text.RegularExpressions;
 using gitlab_ci_runner.helper;
+using gitlab_ci_runner.api;
 
 namespace gitlab_ci_runner.conf
 {
-    class Config
+
+    public class Config
     {
+
+        public class PrebuildConfig
+        {
+            private static string GetValue(IniParser.Model.KeyDataCollection keys, string name)
+            {
+                return keys.ContainsKey(name) ? keys[name] : "";
+            }
+
+            internal PrebuildConfig(BuildInfo b, IniParser.Model.SectionData data)
+            {
+                /*
+                _clone = new CmdConfig(b, data, "Clone");
+                _checkout = new CmdConfig(b, data, "Checkout");
+                _fetch = new CmdConfig(b, data, "Fetch");
+                */
+
+                _projectDir = GetValue(data.Keys, "ProjectDir");
+                _newRepoInit = GetValue(data.Keys, "NewRepoInitCommand");
+                _existingRepoInit = GetValue(data.Keys, "ExistingRepoInitCommand");
+                _postPrepare = GetValue(data.Keys, "PostPrepareCommand");
+                var r = new[] { 
+                    new { key = "{project_dir}", val = "" },
+                    new { key = "{build_id}", val = b.id.ToString() }, 
+                    new { key = "{project_id}", val = b.project_id.ToString() }, 
+                    new { key = "{project_name}", val = Regex.Replace(b.project_name, @"\s+", "") }, 
+                    new { key = "{commit}", val = b.sha }, 
+                    new { key = "{previous_commit}", val = b.before_sha }, 
+                    new { key = "{repo_url}", val = b.repo_url }, 
+                    new { key = "{ref_name}", val = b.ref_name } };
+ 
+                foreach(var rule in r)
+                {
+                    _projectDir = _projectDir.Replace(rule.key, rule.val);
+                }
+
+                r[0] = new { key = "{project_dir}", val =_projectDir};
+                foreach (var rule in r)
+                {
+                    _newRepoInit = _newRepoInit.Replace(rule.key, rule.val);
+                    _existingRepoInit = _existingRepoInit.Replace(rule.key, rule.val);
+                    _postPrepare = _postPrepare.Replace(rule.key, rule.val);
+                }
+
+            }
+
+            private string _projectDir;
+            private string _postPrepare;
+            private string _newRepoInit;
+            private string _existingRepoInit;
+
+            public string ProjectDir { get { return _projectDir; } }
+            public string NewRepoInit { get { return _newRepoInit; } }
+            public string ExistingRepoInit { get { return _existingRepoInit; } }
+            public string PostPrepare { get { return _postPrepare; } }
+        }
+        
         /// <summary>
         /// URL to the Gitlab CI coordinator
         /// </summary>
@@ -52,6 +111,67 @@ namespace gitlab_ci_runner.conf
             IniFile ini = new IniFile(confPath);
             ini.IniWriteValue("main", "url", url);
             ini.IniWriteValue("main", "token", token);
+        }
+
+        public static PrebuildConfig getDataForBuild(gitlab_ci_runner.api.BuildInfo b)
+        {
+            if (!isConfigured())
+            {
+                throw new NotImplementedException("Situation when no configuration file is provided is not supported yet. Make sure that runner.cfg exists at the file location.");
+            }
+            IniParser.FileIniDataParser ini = new IniParser.FileIniDataParser();
+            IniParser.Model.IniData data = ini.ReadFile(confPath);
+
+            IniParser.Model.SectionData section = null;
+            foreach (var sect in data.Sections)
+            {
+                string[] projectIdentifiers = sect.SectionName.Split(new char[] {'|'} );
+                foreach(var p in projectIdentifiers)
+                {
+                    string[] components = p.Split( new char[] {'='} );
+                    if (components.Length == 2)
+                    {
+                        switch (components[0])
+                        {
+                            case "id":
+                                if (Convert.ToInt32(components[1]) == b.project_id)
+                                {
+                                    section = sect;
+                                }
+                                break;
+                            case "name":
+                                if (components[1] == b.project_name || components[1] == Regex.Replace(b.project_name, @"\s+", ""))
+                                {
+                                    section = sect;
+                                }
+                                break;
+                            default:
+                                throw new Exception(String.Format("Cannot parse the {0} due to unknown project filter {1}", confPath, p));
+                        }
+                    }
+                    else 
+                    {
+                        if (p == "*")
+                        {
+                            section = sect;
+                        }
+                        else 
+                        {
+                            if (p!="main")
+                                throw new Exception(String.Format("Cannot parse the {0} while searching for the project prebuild steps commands. Section {1} cannot be recognized.", confPath, p));
+                        }
+                    }
+                    if (section != null)
+                    {
+                        break;
+                    }
+                }
+                if (section != null)
+                {
+                    break;
+                }
+            }
+            return new PrebuildConfig(b, section);
         }
 
         /// <summary>

--- a/gitlab-ci-runner/gitlab-ci-runner.csproj
+++ b/gitlab-ci-runner/gitlab-ci-runner.csproj
@@ -38,6 +38,9 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="INIFileParser">
+      <HintPath>..\packages\ini-parser.2.1.1\lib\INIFileParser.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Experimental.IO">
       <HintPath>..\packages\Microsoft.Experimental.IO.1.0.0.0\lib\NETFramework40\Microsoft.Experimental.IO.dll</HintPath>
     </Reference>
@@ -75,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.manifest" />
+    <None Include="LICENSE" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/gitlab-ci-runner/packages.config
+++ b/gitlab-ci-runner/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ini-parser" version="2.1.1" targetFramework="net40" />
   <package id="Microsoft.Experimental.IO" version="1.0.0.0" targetFramework="net40" />
   <package id="ServiceStack.Client" version="4.0.20" targetFramework="net40" />
   <package id="ServiceStack.Interfaces" version="4.0.20" targetFramework="net40" />


### PR DESCRIPTION
When I first tried this runner, I was a bit confused how to configure the destination folder where it will deploy and run a project/tests. It turned out that this folder is hardcoded (like `projects/project-{id}`). Moreover, the script which receives the project from a repo is also hardcoded which was not flexible for me enough. 

That's why I have modified it a little bit and added an ability to define all these things in the `runner.cfg`. I have described how to use it in the readme.MD but in short, the changes are the following: 
1. You can specify the destination folder. 
2. You can define a command (or commands) to run when it tries to grab a project from a scratch (clone). 
3. You can define a command (or commands) to run when it a project already exists (clone). 
4. You can define a command to run after the project is updated. 
5. You can specify different settings for different projects identified by a project name or id (or define it globally using asterisk). 
6. You can use placeholders for values sent by CI such as project id/name, build id, commit sha, etc. 

Hopefully you will find it useful. 
