### PR TITLE
Fixed buildInfo to actually match the CI API

### DIFF
--- a/gitlab-ci-runner/api/API.cs
+++ b/gitlab-ci-runner/api/API.cs
@@ -122,7 +122,7 @@ namespace gitlab_ci_runner.api
 			set;
 		}
 
-		public string ref_name
+		public string @ref
 		{
 			get;
 			set;

--- a/gitlab-ci-runner/runner/Build.cs
+++ b/gitlab-ci-runner/runner/Build.cs
@@ -202,7 +202,7 @@ namespace gitlab_ci_runner.runner
                 p.StartInfo.EnvironmentVariables["CI_SERVER_REVISION"] = null; // GitlabCI Revision
 
                 p.StartInfo.EnvironmentVariables["CI_BUILD_REF"] = buildInfo.sha;
-                p.StartInfo.EnvironmentVariables["CI_BUILD_REF_NAME"] = buildInfo.ref_name;
+                p.StartInfo.EnvironmentVariables["CI_BUILD_REF_NAME"] = buildInfo.@ref;
                 p.StartInfo.EnvironmentVariables["CI_BUILD_ID"] = buildInfo.id.ToString();
 
                 // Redirect Standard Output and Standard Error

--- a/runner.Build.success.test/BuildTest.cs
+++ b/runner.Build.success.test/BuildTest.cs
@@ -80,7 +80,7 @@ namespace runner.Build.success.test
             buildInfo.repo_url = "https://github.com/randx/six.git";
             buildInfo.sha = "2e008a711430a16092cd6a20c225807cb3f51db7";
             buildInfo.timeout = 1800;
-            buildInfo.ref_name = "master";
+            buildInfo.@ref = "master";
 
             gitlab_ci_runner.runner.Build target = new gitlab_ci_runner.runner.Build(buildInfo);
             target.run();


### PR DESCRIPTION
The build info network helper would previously set "ref_name" from the JSON returned by the CI. As the CI returns "ref" rather than "ref_name", this would give a null value, preventing access to the name of the branch.

This fix works on Gitlab CI 5.4.1.
